### PR TITLE
feat: use a Github app for final commit

### DIFF
--- a/.github/workflows/create-code-json.yml
+++ b/.github/workflows/create-code-json.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "data/raw/**"
   workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * 6' # https://crontab.guru/#0_13_*_*_6
 
 concurrency:
   group: ${{ github.workflow }}
@@ -51,7 +53,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Download code.json artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -59,6 +61,23 @@ jobs:
           name: code-json
           path: data/
 
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ vars.GIT_APP_OCIO_SHAREIT_APP_ID }}
+          private-key: ${{ secrets.GIT_APP_OCIO_SHAREIT_PRIVATE_KEY }}
+
       - name: Commit and push changes
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git status
+          git config --global user.email "${{ vars.GIT_APP_OCIO_SHAREIT_APP_ID }}+${{ vars.GIT_APP_OCIO_SHAREIT_APP_NAME }}[bot]@users.noreply.github.com"
+          git config --global user.name "${{ vars.GIT_APP_OCIO_SHAREIT_APP_NAME }}[bot]"
+          git config remote.origin.url 'https://${{ vars.GIT_APP_OCIO_SHAREIT_APP_ID }}:${{ env.GH_TOKEN }}@github.com/cdcgov/shareit-act.git'
+          git add data/code.json
+          if ! git diff-index --quiet HEAD; then
+            git commit --allow-empty -m "Automate update of code.json - $(date +'%Y-%m-%d')"
+            git pull --rebase origin main
+            git push
+          fi

--- a/.github/workflows/update-github-orgs.yml
+++ b/.github/workflows/update-github-orgs.yml
@@ -24,7 +24,7 @@ jobs:
             cdc-data,
             cdc-his,
             cdcai,
-            # cdcent,
+            cdcent,
             cdcepi,
             cdcgov,
             informaticslab,
@@ -91,6 +91,32 @@ jobs:
           echo "Files in data/raw:"
           ls -la data/raw/
 
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ vars.GIT_APP_OCIO_SHAREIT_APP_ID }}
+          private-key: ${{ secrets.GIT_APP_OCIO_SHAREIT_PRIVATE_KEY }}
+
       - name: Commit and push changes
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git status
+
+      # This is commented out as we're waiting for approval to push this information.
+      # - name: Commit and push changes
+      #   if: github.ref == 'refs/heads/main'
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      #   run: |
+      #     git config --global user.email "${{ vars.GIT_APP_OCIO_SHAREIT_APP_ID }}+${{ vars.GIT_APP_OCIO_SHAREIT_APP_NAME }}[bot]@users.noreply.github.com"
+      #     git config --global user.name "${{ vars.GIT_APP_OCIO_SHAREIT_APP_NAME }}[bot]"
+      #     git config remote.origin.url 'https://${{ vars.GIT_APP_OCIO_SHAREIT_APP_ID }}:${{ env.GH_TOKEN }}@github.com/cdcgov/shareit-act.git'
+      #     git add data/raw/*
+      #     if ! git diff-index --quiet HEAD; then
+      #       git commit --allow-empty -m "Automate update of raw repository - $(date +'%Y-%m-%d')"
+      #       git pull --rebase origin main
+      #       git push
+      #     fi
+


### PR DESCRIPTION
## Additions

- Setting up a workflow for checking it in using a Github App with write permissions to the repository so that we're ready to merge in the ShareIT requirements.
- Make code.json generation into a weekly cron job.

## Updates

- Adding cdcent as part of the workflow (which could take a while).

## Testing Steps

- None, letting Github action take over. (Static linting using actionlint, zizmor).

## Notes

-
