### PR TITLE
fix: uv will auto install requirements

### DIFF
--- a/.github/workflows/create-code-json.yml
+++ b/.github/workflows/create-code-json.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           version: "latest"
 
-      - name: Install dependencies
-        run: uv pip install -r requirements.txt
-
       - name: Running combine script
         run: |
           uv run python main.py --combine --output data/


### PR DESCRIPTION
## Updates

- fixing a broken pipeline for code.json generation; uv doesn't need us to explicitly install requirements, it'll do that by itself.

## Testing Steps

-

## Notes

-
