### PR TITLE
fix: hiding a problem where the JWT token expires within an hour by running faster

### DIFF
--- a/src/repository.py
+++ b/src/repository.py
@@ -3,32 +3,37 @@ from github import Github
 from github import GithubIntegration
 
 class Repository:
-  def authenticate(self, credentials):
-    app_id = credentials.get('github_app_id', '')
-    installation_id = credentials.get('github_app_installation_id', '')
-    private_key = credentials.get('github_app_private_key', '')
+
+  def __init__(self, credentials=None):
+    self.credentials = credentials
+
+  def authenticate(self):
+    app_id = self.credentials.get('github_app_id', '')
+    installation_id = self.credentials.get('github_app_installation_id', '')
+    private_key = self.credentials.get('github_app_private_key', '')
 
     ## Use the Github personal access token for authentication
     ## Otherwise, use GitHub App authentication
     ## This is just a personal preference, either is fine.
-    if 'github_token' in credentials and credentials['github_token']:
-      return Github(credentials['github_token'])
+    if 'github_token' in self.credentials and self.credentials['github_token']:
+      return Github(self.credentials['github_token'])
     auth = Auth.AppAuth(app_id, private_key)
     gi = GithubIntegration(auth=auth)
     access_token = gi.get_access_token(installation_id).token
     return Github(access_token)
 
-  def get_repos(self, credentials):
-    g = self.authenticate(credentials)
-    org_name = credentials.get('github_org')
+  def get_repos(self):
+    g = self.authenticate()
+    org_name = self.credentials.get('github_org')
     org = g.get_organization(org_name)
     repos = list(
       org.get_repos(type='all')
     )
+    print(f"Found {len(repos)} repositories in Github.com organization {org_name}")
     return repos
 
-  def get_repo_by_id(self, credentials, repo_id):
-    g = self.authenticate(credentials)
+  def get_repo_by_id(self, repo_id):
+    g = self.authenticate(self.credentials)
     try:
       repo = g.get_repo(int(repo_id))
       return repo


### PR DESCRIPTION
## Updates

- fix: hide the problem where the JWT token expires within an hour; [cdcent](https://github.com/cdcent) won't complete within an hour, so many of the last requests will fail, resulting in an inconsistent upload of its code.json output.
<img width="3628" height="1876" alt="image" src="https://github.com/user-attachments/assets/c60c2c4d-51c7-454e-a470-6ad6332b9fbc" />
- hide the problem by... running it multi-threaded - Github standard Linux machines runs 2 cores, so use 4 threads for maximizing the thread throughput limit as this is an I/O bounded problem.
- wrote down #59 to fix later; kicking barrel down the road until I have more time to properly fix this.

## Testing Steps

- Tested locally, ran against [cdcent](https://github.com/cdcent) and completed within 20 minutes.

## Notes

-
