### PR TITLE
feat: add rules for private repositories

### DIFF
--- a/.github/workflows/create-code-json.yml
+++ b/.github/workflows/create-code-json.yml
@@ -8,7 +8,7 @@ on:
       - "data/raw/**"
   workflow_dispatch:
   schedule:
-    - cron: '0 13 * * 6' # https://crontab.guru/#0_13_*_*_6
+    - cron: "0 13 * * 6" # https://crontab.guru/#0_13_*_*_6
 
 concurrency:
   group: ${{ github.workflow }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Running combine script to create code.json
         run: |
-          uv run python main.py --combine --output data/
+          uv run python main.py --combine --public --output data/
 
       - name: Upload code.json file
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/main.py
+++ b/main.py
@@ -89,6 +89,8 @@ def main():
   parser = argparse.ArgumentParser(description='Process GitHub organization')
   parser.add_argument('--output', help='Output directory path')
   parser.add_argument('--combine', action='store_true', help='Combine all JSON files in data/raw directory')
+  parser.add_argument('--filter', action='store_true', help='Filter repositories by criteria, only used with --combine')
+  parser.add_argument('--public-only', action='store_true', help='Filter repositories by public repositories, only used with --combine')
   parser.add_argument('--generate-csv', action='store_true', help='Generate privateid_mapping.csv from code.json')
   parser.add_argument('--repo-id', help='Run inference for a single repo ID and output one file')
   args = parser.parse_args()
@@ -96,7 +98,27 @@ def main():
   now = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
   print(f"Process starting: {now}")
 
-  if args.combine:
+  if args.combine and args.filter:
+    credentials = Config().credentials()
+    input_dir = credentials.get('raw_data_dir', 'data/raw')
+    if input_dir == 'data/raw':
+      input_dir = str(Path(__file__).parent.absolute() / 'data/raw')
+    Combine().combine_json_files_with_filter(input_dir, args.output)
+    now = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    print(f"Completed processing at {now}")
+    return
+
+  elif args.combine and args.public_only:
+    credentials = Config().credentials()
+    input_dir = credentials.get('raw_data_dir', 'data/raw')
+    if input_dir == 'data/raw':
+      input_dir = str(Path(__file__).parent.absolute() / 'data/raw')
+    Combine().combine_json_files_with_public(input_dir, args.output)
+    now = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    print(f"Completed processing at {now}")
+    return
+
+  elif args.combine and not args.filter and not args.public_only:
     credentials = Config().credentials()
     input_dir = credentials.get('raw_data_dir', 'data/raw')
     if input_dir == 'data/raw':

--- a/src/combine.py
+++ b/src/combine.py
@@ -1,8 +1,188 @@
 import json
 
+from datetime import datetime
 from pathlib import Path
 
 class Combine:
+
+  ###########################################################
+  ## We were asked to censor particular metadata information
+  ## for code.json output based on certain criteria.
+  ##
+  ## 1. username being abc1 is no longer part of the email
+  ## 2. internal URLs are no longer displayed.
+  ##
+  ##########################################################
+  def censor_information(self, filename, repo):
+    censored = dict(repo)
+    if self.to_exclude_private_repository(filename, repo):
+      censored.pop('_url', None)
+      censored['contact'] = {}
+      censored['contact']['email'] = "shareit@cdc.gov"
+      censored['homepageURL'] = ""
+      censored['repositoryURL'] = ""
+    return censored
+
+  def is_past_cutoff_date(self, cutoff_date, date):
+    try:
+      dt_cutoff = datetime.fromisoformat(cutoff_date.replace("Z", "+00:00"))
+      dt_date = datetime.fromisoformat(date.replace("Z", "+00:00"))
+      return dt_date < dt_cutoff
+    except Exception as e:
+      print(f"Could not parse date: {date} ({e})")
+    return False
+
+  def to_exclude_private_repository(self, filename, repo):
+    if "ado" in filename.lower() or "gitlab" in filename.lower():
+      return True
+    if repo.get('repositoryVisibility', '').lower() == 'private':
+      is_private = repo.get('repositoryVisibility', '').lower() == 'private'
+      if is_private:
+        return True
+    return False
+
+  ###########################################################
+  ## We were asked to exclude certain repositories
+  ## for code.json output based on certain criteria.
+  ##
+  ## 1. When including "private" repositories, only
+  ## include repositories updated on or after June 21 2025.
+  ## 2. Repositories that are in Gitlab or Azure Devops
+  ## are hosted internal to CDC are considered "private".
+  ## 3. Github Enterprise Cloud (github.com) repositories
+  ## are considered public unless they are marked private
+  ##
+  ##########################################################
+  def to_exclude_repository(self, filename, repo):
+    if "ado" in filename.lower() or "gitlab" in filename.lower():
+      last_modified = repo.get('date', {}).get('lastModified', '')
+      if last_modified and self.is_past_cutoff_date("2025-06-21T00:00:00Z", last_modified):
+        return True
+      return False
+
+    if repo.get('repositoryVisibility', '').lower() == 'private':
+      last_modified = repo.get('date', {}).get('lastModified', '')
+      is_private = repo.get('repositoryVisibility', '').lower() == 'private'
+      if is_private:
+        if last_modified and self.is_past_cutoff_date("2025-06-21T00:00:00Z", last_modified):
+          return True
+    return False
+
+  def combine_json_files_with_public(self, input_dir, output_dir=None):
+    raw_data_path = Path(input_dir)
+    if not raw_data_path.exists() or not raw_data_path.is_dir():
+      print(f"Directory not found: {raw_data_path}")
+      return None
+
+    print(f"Combining JSON files from {raw_data_path}")
+    json_files = list(raw_data_path.glob('*.json'))
+    if not json_files:
+      print("No JSON files found")
+      return None
+
+    combined_data = []
+    for file_path in json_files:
+      print(f"Reading {file_path.name}")
+      try:
+        with open(file_path, 'r') as f:
+          data = json.load(f)
+          if not isinstance(data, list):
+            print(f"Error: {file_path.name} does not contain a list of objects, skipping")
+            continue
+          for repo in data:
+            to_exclude = self.to_exclude_private_repository(file_path.name, repo)
+            if not to_exclude:
+              if isinstance(repo, dict) and "description" not in repo:
+                repo["description"] = ""
+              combined_data.append(repo)
+
+      except json.JSONDecodeError:
+        print(f"Error: {file_path.name} is not valid JSON, skipping")
+      except Exception as e:
+        print(f"Error processing {file_path.name}: {e}")
+
+    if not combined_data:
+      print("No valid data found")
+      return None
+
+    output_path = Path(output_dir if output_dir else input_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    output_file = output_path / "code.json"
+
+    data = {
+      "version": "2.0",
+      "agency": "CDC",
+      "measurementType": {
+          "method": "projects"
+      },
+      "projects": combined_data
+    }
+
+    with open(output_file, 'w') as f:
+      json.dump(data, f, indent=2)
+
+    print(f"Combined data saved to {output_file}")
+    print(f"Total repositories: {len(combined_data)}")
+    return str(output_file)
+
+  def combine_json_files_with_filter(self, input_dir, output_dir=None):
+    raw_data_path = Path(input_dir)
+    if not raw_data_path.exists() or not raw_data_path.is_dir():
+      print(f"Directory not found: {raw_data_path}")
+      return None
+
+    print(f"Combining JSON files from {raw_data_path}")
+    json_files = list(raw_data_path.glob('*.json'))
+    if not json_files:
+      print("No JSON files found")
+      return None
+
+    combined_data = []
+    for file_path in json_files:
+      print(f"Reading {file_path.name}")
+      try:
+        with open(file_path, 'r') as f:
+          data = json.load(f)
+          if not isinstance(data, list):
+            print(f"Error: {file_path.name} does not contain a list of objects, skipping")
+            continue
+          for obj in data:
+            to_exclude = self.to_exclude_repository(file_path.name, obj)
+            censored = self.censor_information(file_path.name, obj)
+            if not to_exclude:
+              if "description" not in censored:
+                censored["description"] = ""
+              combined_data.append(censored)
+
+      except json.JSONDecodeError:
+        print(f"Error: {file_path.name} is not valid JSON, skipping")
+      except Exception as e:
+        print(f"Error processing {file_path.name}: {e}")
+
+    if not combined_data:
+      print("No valid data found")
+      return None
+
+    output_path = Path(output_dir if output_dir else input_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    output_file = output_path / "code.json"
+
+    data = {
+      "version": "2.0",
+      "agency": "CDC",
+      "measurementType": {
+          "method": "projects"
+      },
+      "projects": combined_data
+    }
+
+    with open(output_file, 'w') as f:
+      json.dump(data, f, indent=2)
+
+    print(f"Combined data saved to {output_file}")
+    print(f"Total repositories: {len(combined_data)}")
+    return str(output_file)
+
   def combine_json_files(self, input_dir, output_dir=None):
     raw_data_path = Path(input_dir)
     if not raw_data_path.exists() or not raw_data_path.is_dir():
@@ -10,7 +190,6 @@ class Combine:
       return None
 
     print(f"Combining JSON files from {raw_data_path}")
-
     json_files = list(raw_data_path.glob('*.json'))
     if not json_files:
       print("No JSON files found")


### PR DESCRIPTION
## Updates

- We were told to add rulesets for private repositories to filter them out of code.json. This change reflects a set of rules during the combination steps to generate that.
- Code.json only has public repositories during the internal review process.
- Add date criteria to include repositories made or modified after June 21 2025 according to interpretation of ShareIT Act.

## Testing Steps

- Tested CLI locally.

## Notes

-
