### PR TITLE
Update index to include releases array

### DIFF
--- a/data/code.json
+++ b/data/code.json
@@ -4,7 +4,7 @@
   "measurementType": {
     "method": "projects"
   },
-  "projects": [
+  "releases": [
     {
       "name": "cdcgov.github.io",
       "organization": "CDC",

--- a/src/combine.py
+++ b/src/combine.py
@@ -115,7 +115,7 @@ class Combine:
       "measurementType": {
           "method": "projects"
       },
-      "projects": combined_data
+      "releases": combined_data
     }
 
     with open(output_file, 'w') as f:
@@ -173,7 +173,7 @@ class Combine:
       "measurementType": {
           "method": "projects"
       },
-      "projects": combined_data
+      "releases": combined_data
     }
 
     with open(output_file, 'w') as f:
@@ -231,7 +231,7 @@ class Combine:
       "measurementType": {
           "method": "projects"
       },
-      "projects": combined_data
+      "releases": combined_data
     }
 
     with open(output_file, 'w') as f:


### PR DESCRIPTION
## Updates

- In `code.json`, updated `projects` array to be `releases` so it follows code.json agency schema
- Update mentions of `projects` to `releases` in scripts that generate code.json agency index

## Testing Steps

-

## Notes

- More information about the agency index schema/file here: https://github.com/DSACMS/gov-codejson/blob/main/docs/agency-index.md
- Schema: https://github.com/DSACMS/gov-codejson/blob/main/schemas/agency-index/schema-2.0.0.json
  - This is essentially the same as GSA code.json schema from M16-21: https://github.com/GSA/code-gov-data/blob/master/schemas/schema-2.0.0.json
